### PR TITLE
Fixed bug with `--use-length` option, added some more flags, configured ruff

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ service-lookup --root /path/to/root --map service1=localhost:8080,service2=local
 - `-n`, `--namespace`: Kubernetes namespace to discover services.
 - `-s`, `--services`: Comma-separated list of service names to port forward. Default value is '*' which means every service in the mapping file.
 - `-f`, `--mapping-file`: Path to JSON file with service_name -> kubernetes_service_name mappings.
+- `-k`, `--kubeconfig`: Specify kubeconfig file path.
+- `-c`, `--cluster`: Specify Kubernetes cluster, otherwise first matching namespace from any cluster will be used when using the `--use-lens` option.
 - `-l`, `--use-lens`: Use kubeconfigs from Lens.
+- `-t`, `--request-timeout`: The length of time to wait before giving up on a single server request, default is 10s.
 
 ## Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "service-lookup"
-version = "0.2.7"
+version = "0.2.8"
 description = "Update host:port in YAML service URLs by service name and Kubernetes cluster"
 authors = [
   { name="Pavlos Smith", email="paulsmith4561@proton.me" },
@@ -19,3 +19,24 @@ repository = "https://pypi.org/project/service-lookup/"
 
 [project.scripts]
 service-lookup = "service_lookup.main:main"
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+  # pycodestyle
+  "E",
+  # Pyflakes
+  "F",
+  # pyupgrade
+  "UP",
+  # flake8-bugbear
+  "B",
+  # flake8-simplify
+  "SIM",
+  # isort
+  "I",
+  # warnings
+  "W"
+]

--- a/src/service_lookup/clean_processes.py
+++ b/src/service_lookup/clean_processes.py
@@ -1,8 +1,9 @@
 """Kills processes based on ther listening port"""
 
-import subprocess
 import os
 import signal
+import subprocess
+
 
 def get_pids_for_ports(ports):
     """Retrieve PIDs for processes listening on specified ports."""

--- a/src/service_lookup/kubeconfig_setup.py
+++ b/src/service_lookup/kubeconfig_setup.py
@@ -62,6 +62,8 @@ def get_lens_kubeconfig_for_namespace(namespace, request_timeout, cluster=None):
     return kubeconfig_files[0]
 
 def namespace_matches(namespace, actual_namespace):
-    # Also matches namespaces with an added suffix separated with . or -
-    return namespace in actual_namespace.split('.') or namespace in actual_namespace.split('-')
+    """Matches input namespace with the ones found from the cluster.
 
+    It also matches namespaces with an added suffix separated with . or -
+    """
+    return namespace in actual_namespace.split('.') or namespace in actual_namespace.split('-')

--- a/src/service_lookup/kubeconfig_setup.py
+++ b/src/service_lookup/kubeconfig_setup.py
@@ -1,14 +1,23 @@
-""" Generates a [name, kubeconfig] map from Lens kubeconfigs. """
+""" Finds Lens kubeconfig by namespace and cluster """
 
+import os
 from pathlib import Path
+
 from ruamel.yaml import YAML
+
+from .kubectl_service import KubectlService
 
 yaml = YAML()
 yaml.preserve_quotes = True
 
-def get_kubeconfigs():
-    """Generates a map from namespace or cluster name to kubeconfig file path."""
-    lens_kubeconfigs_dir = Path.home() / "AppData" / "Roaming" / "Lens" / "kubeconfigs"
+def get_lens_kubeconfig_for_namespace(namespace, request_timeout, cluster=None):
+    """Find the Lens kubeconfig file for a given namespace.
+
+    A specific cluster name can be given, otherwise the first match will be returned.
+    """
+
+    lens_kubeconfigs_dir = Path.home() / "AppData" / "Roaming" / "Lens" / "kubeconfigs" \
+        if os.name == 'nt' else Path.home() / ".lens" / "kubeconfigs"
 
     if not lens_kubeconfigs_dir.exists():
         print("Lens kubeconfigs directory not found. Ensure Lens is installed and configured.")
@@ -19,21 +28,40 @@ def get_kubeconfigs():
         print("No kubeconfig files found in the Lens directory.")
         return None
 
-    namespace_to_kubeconfig = {}
-
     for kubeconfig_file in kubeconfig_files:
         try:
-            with open(kubeconfig_file, 'r', encoding="utf-8") as f:
+            with open(kubeconfig_file, encoding="utf-8") as f:
                 kubeconfig_data = yaml.load(f)
 
+            print(f"Checking kubeconfig: '{kubeconfig_file}'...")
+
+            kubectl = KubectlService(kubeconfig_file)
+
             for context in kubeconfig_data.get('contexts', []):
-                namespace = context.get('context', {}).get('namespace')
-                cluster = context.get('context', {}).get('cluster')
-                if namespace:
-                    namespace_to_kubeconfig[namespace] = str(kubeconfig_file)
-                elif cluster:
-                    namespace_to_kubeconfig[cluster] = str(kubeconfig_file)
+                cluster_curr = context.get('context', {}).get('cluster')
+
+                # Skip unnecessary check if specific cluster was given
+                if cluster is not None and cluster_curr != cluster:
+                    continue
+
+                namespaces = kubectl.get_namespaces(context.get('name'), request_timeout)
+
+                if namespaces is None:
+                    continue
+
+                found_namespace = next((ns for ns in namespaces.get('items')
+                    if namespace_matches(namespace, ns.get('metadata').get('name'))), None)
+
+                if found_namespace is not None:
+                    return str(kubeconfig_file)
         except OSError as e:
             print(f"Error reading {kubeconfig_file}: {e}")
 
-    return namespace_to_kubeconfig
+    print(f"Error: No matching kubeconfig found for namespace '{namespace}'.")
+    print(f"Warning: Using '{kubeconfig_files[0]}' as a fallback.")
+    return kubeconfig_files[0]
+
+def namespace_matches(namespace, actual_namespace):
+    # Also matches namespaces with an added suffix separated with . or -
+    return namespace in actual_namespace.split('.') or namespace in actual_namespace.split('-')
+

--- a/src/service_lookup/kubectl_service.py
+++ b/src/service_lookup/kubectl_service.py
@@ -1,19 +1,14 @@
-
 """
 kubectl_service.py
 
 Provides a KubectlService class that wraps kubectl commands\
 for interacting with Kubernetes clusters.
-
-This abstraction allows:
-- Switching Kubernetes contexts
-- Retrieving services from a namespace
-- Port-forwarding services to localhost
 """
 
+import json
 import subprocess
 import threading
-import json
+
 
 class KubectlService:
     """
@@ -22,6 +17,7 @@ class KubectlService:
     This service provides higher-level methods to interact with Kubernetes clusters, such as:
     - Switching contexts
     - Retrieving services in a namespace
+    - Retrieving namespaces by context
     - Port-forwarding services to localhost
     """
 
@@ -58,7 +54,7 @@ class KubectlService:
         Args:
             context (str): The name of the Kubernetes context to switch to.
         """
-        print(f"Switching context to '{context}' using kubeconfig '{self.kubeconfig}'\n")
+        print(f"Switching context to '{context}' using kubeconfig '{self.kubeconfig}'")
         self.run_kubectl(["config", "use-context", context])
 
     def get_services(self, namespace):
@@ -73,6 +69,24 @@ class KubectlService:
         """
         result = self.run_kubectl(["get", "services", "-n", namespace, "-o", "json"])
         return json.loads(result.stdout)
+
+    def get_namespaces(self, context, request_timeout="10s"):
+        """
+        Retrieves all namespaces from given context.
+
+        Args:
+           context (str): The name of the Kubernetes context to switch to.
+
+        Returns:
+           dict: A dictionary representing the JSON output of the namespaces list.
+        """
+        try:
+            result = self.run_kubectl(["get", "namespace", "--context", context, "-o", "json",
+                                      "--request-timeout", request_timeout])
+            return json.loads(result.stdout)
+        except subprocess.CalledProcessError:
+            print(f"Error getting namespaces for context '{context}', returning none")
+            return None
 
     def port_forward(self, namespace, service_name, local_port, target_port):
         """

--- a/src/service_lookup/lookup_cluster.py
+++ b/src/service_lookup/lookup_cluster.py
@@ -1,10 +1,11 @@
 """Looks up services in a Kubernetes cluster, and returns a map with the forwarded local ports"""
 
-import subprocess
 import json
 import socket
-from pathlib import Path
+import subprocess
+
 from ruamel.yaml import YAML
+
 from .kubectl_service import KubectlService
 
 yaml = YAML()
@@ -19,7 +20,7 @@ def get_free_port():
 def load_service_mappings(mapping_file):
     """Load service mappings from a JSON file."""
     try:
-        with open(mapping_file, 'r', encoding="utf-8") as f:
+        with open(mapping_file, encoding="utf-8") as f:
             return json.load(f)
     except FileNotFoundError:
         print(f"Mapping file {mapping_file} not found.")
@@ -28,27 +29,10 @@ def load_service_mappings(mapping_file):
         print("Error decoding JSON mapping file.")
         return {}
 
-def get_kubeconfig_for_namespace(namespace, kubeconfigs):
-    """Find the kubeconfig file for a given namespace."""
-
-    # Try to find an exact match for the namespace
-    if namespace in kubeconfigs:
-        print(kubeconfigs[namespace])
-        return kubeconfigs[namespace]
-
-    # Try to find a match by splitting on delimiters
-    for key in kubeconfigs:
-        if namespace in key.split('.') or namespace in key.split('-'):
-            return kubeconfigs[key]
-
-    print(f"Error: No matching kubeconfig found for namespace '{namespace}'.")
-    print(f"Warning: Using '{kubeconfigs[0]}' as a fallback.")
-    return kubeconfigs[0]
-
 def get_context_from_kubeconfig(kubecfg):
     """Extract the context name from a kubeconfig file."""
     try:
-        with open(kubecfg, 'r', encoding='utf-8') as f:
+        with open(kubecfg, encoding='utf-8') as f:
             config = yaml.load(f)
             current_context = config.get('current-context')
             if current_context:
@@ -85,16 +69,10 @@ def port_forward_services(service_filter, service_mappings, services, namespace,
 
 
 def discover_services_and_port_forward(namespace, service_filter,
-    service_mappings, kubeconfigs=None):
+    service_mappings, kubecfg):
 
     """Looks up services in a Kubernetes cluster, returns a map with the forwarded local ports."""
     try:
-        kubecfg = (
-            get_kubeconfig_for_namespace(namespace, kubeconfigs)
-            if kubeconfigs else
-            Path.home() / ".kube" / "config"
-        )
-
         context_name = get_context_from_kubeconfig(kubecfg)
         if not context_name:
             print("Failed to determine context.")

--- a/src/service_lookup/main.py
+++ b/src/service_lookup/main.py
@@ -53,7 +53,8 @@ Default value is '*' which means every service in the mapping file", default="*"
         else:
             service_filter = args.services.split(',')
 
-        kubeconfig = get_kubeconfig(args.use_lens, args.kubeconfig, args.namespace, args.request_timeout, args.cluster)
+        kubeconfig = get_kubeconfig(args.use_lens, args.kubeconfig, args.namespace,
+                                    args.request_timeout, args.cluster)
 
         replacements = discover_services_and_port_forward(
             args.namespace, service_filter, service_mappings, kubeconfig)
@@ -78,6 +79,8 @@ they are going to be cleaned:\n{unused_services}\n")
     clean_ports([replacements[used_service] for used_service in used_services])
 
 def get_kubeconfig(use_lens, kubeconfig, namespace, request_timeout, cluster):
+    """Gets the appropriate kubeconfig depending on the options given."""
+
     if use_lens:
         return get_lens_kubeconfig_for_namespace(namespace, request_timeout, cluster)
     if kubeconfig is None:

--- a/src/service_lookup/main.py
+++ b/src/service_lookup/main.py
@@ -2,11 +2,14 @@
 
 import argparse
 from pathlib import Path
+
 import keyboard
-from .uri_updater import update_directory
-from .lookup_cluster import discover_services_and_port_forward, load_service_mappings
-from .kubeconfig_setup import get_kubeconfigs
+
 from .clean_processes import clean_ports
+from .kubeconfig_setup import get_lens_kubeconfig_for_namespace
+from .lookup_cluster import discover_services_and_port_forward, load_service_mappings
+from .uri_updater import update_directory
+
 
 def wait_for_user_command():
     """Wait for a specific user command to trigger cleanup."""
@@ -19,12 +22,18 @@ def main():
     """Driver for service-lookup utility"""
     parser = argparse.ArgumentParser(description="Update host:port in YAML service \
         URLs by service name and Kubernetes cluster")
+    parser.add_argument('-k', '--kubeconfig', help="Specify kubeconfig file path")
     parser.add_argument('-l', '--use-lens', action='store_true',
         help="Search kubeconfigs from Lens")
-    parser.add_argument('-r', '--root', help="Root directory to search YAML files")
+    parser.add_argument('-r', '--root', help="Root directory to search YAML files, \
+the default is the current directory", default=".")
     parser.add_argument('-e', '--exclude', help="Excluded paths in root directory")
     parser.add_argument('-m', '--map', help="Comma-separated service=host:port pairs")
+    parser.add_argument('-c', '--cluster', help="Specify Kubernetes cluster, \
+otherwise first matching namespace from any cluster will be used when using the --use-lens option")
     parser.add_argument('-n', '--namespace', help="Kubernetes namespace to discover services")
+    parser.add_argument('-t', '--request-timeout', help="The length of time to wait before \
+giving up on a single server request, default is 10s", default="10s")
     parser.add_argument('-s', '--services',
         help="Comma-separated list of service names to port forward. \
 Default value is '*' which means every service in the mapping file", default="*")
@@ -44,17 +53,13 @@ Default value is '*' which means every service in the mapping file", default="*"
         else:
             service_filter = args.services.split(',')
 
+        kubeconfig = get_kubeconfig(args.use_lens, args.kubeconfig, args.namespace, args.request_timeout, args.cluster)
+
         replacements = discover_services_and_port_forward(
-            args.namespace, service_filter, service_mappings,
-            get_kubeconfigs() if args.use_lens else None
-        )
+            args.namespace, service_filter, service_mappings, kubeconfig)
     else:
         print("Error: You must either provide a Kubernetes cluster namespace \
 and selected services, or a service=host:port map.")
-        return
-
-    if not args.root:
-        print("Error: Root directory to be searched must be provided.")
         return
 
     root_path = Path(args.root)
@@ -71,6 +76,13 @@ they are going to be cleaned:\n{unused_services}\n")
 
     print(f"Exiting and cleaning port forwarded services:\n{used_services}\n")
     clean_ports([replacements[used_service] for used_service in used_services])
+
+def get_kubeconfig(use_lens, kubeconfig, namespace, request_timeout, cluster):
+    if use_lens:
+        return get_lens_kubeconfig_for_namespace(namespace, request_timeout, cluster)
+    if kubeconfig is None:
+        return Path.home() / ".kube" / "config"
+    return kubeconfig
 
 if __name__ == "__main__":
     main()

--- a/src/service_lookup/uri_updater.py
+++ b/src/service_lookup/uri_updater.py
@@ -2,6 +2,7 @@
 
 import re
 from pathlib import Path
+
 from ruamel.yaml import YAML
 
 yaml = YAML()
@@ -13,7 +14,7 @@ def replace_host_port(url, new_host_port):
 
 def update_yaml_urls_by_key(file_path, replacements):
     """Update URI properties by service name"""
-    with open(file_path, 'r', encoding="utf-8") as f:
+    with open(file_path, encoding="utf-8") as f:
         data = yaml.load(f)
 
     updated = set()

--- a/uv.lock
+++ b/uv.lock
@@ -2703,7 +2703,7 @@ wheels = [
 
 [[package]]
 name = "service-lookup"
-version = "0.2.2"
+version = "0.2.7"
 source = { virtual = "." }
 dependencies = [
     { name = "keyboard" },


### PR DESCRIPTION
- Fixed bug with the `--use-lens` option failing to find a kubeconfig in multiple namespace setups.
- Added Linux path for Lens kubeconfigs.
- Added `--kubeconfig` option to be able to specify a specific kubeconfig file path.
- Added `--cluster` option to be able to specify the cluster name to be used with the `--use-lens` option, otherwise it will use the first match and will also be slower due to the multiple `get namespace` calls.
- Added ruff configuration in `pyproject.toml`.
- Updated README
- Bumped project version