### PR TITLE
fix: use platformdirs for cross-platform cache path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.12"
 license = "GPL-3.0"
 dependencies = [
     "keyboard>=0.13.5",
+    "platformdirs>=4.0.0",
     "psutil>=7.2.2",
     "pynput>=1.8.1",
     "ruamel-yaml>=0.18.14",

--- a/src/service_lookup/kubeconfig_setup.py
+++ b/src/service_lookup/kubeconfig_setup.py
@@ -5,6 +5,7 @@ import os
 import time
 from pathlib import Path
 
+import platformdirs
 from ruamel.yaml import YAML
 
 from .kubectl_service import KubectlService
@@ -35,7 +36,7 @@ def get_lens_kubeconfig_for_namespace(namespace, request_timeout, cache_invalida
         print("No kubeconfig files found in the Lens directory.")
         return None
 
-    cache_file = Path.home() / ".cache" / "service-lookup" / "namespaces.yaml"
+    cache_file = Path(platformdirs.user_cache_dir("service-lookup", ensure_exists=True)) / "namespaces.yaml"
     cache_updated = False
     if not cache_file.exists():
         cache_file.parent.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
## Description

Replace the hardcoded `~/.cache/service-lookup` path with `platformdirs.user_cache_dir()` to get the correct OS-specific cache directory.

- **Linux/macOS**: `~/.cache/service-lookup` (unchanged)
- **Windows**: `C:\Users\<User>\AppData\Local\service-lookup` ✅

## Changes

1. Added `platformdirs>=4.0.0` to `pyproject.toml` dependencies
2. Replaced `Path.home() / ".cache" / "service-lookup" / "namespaces.yaml"` with `Path(platformdirs.user_cache_dir("service-lookup", ensure_exists=True)) / "namespaces.yaml"` in `kubeconfig_setup.py`

Fixes #19